### PR TITLE
Consumer service enhancements

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -28,6 +28,8 @@ module.exports = {
 			topic: '',
 			// Consumer group Kafka will track current offset for
 			groupId: 'metamorphosis-consumer-group',
+			// Whether the topic should consume from the first or latest offset if none are found for consumer group. Default is `false`.
+			fromBeginning: false,
 			// Timeout in milliseconds used to detect failures. The consumer sends periodic heartbeats to indicate its liveness to the broker. If no heartbeats are received by the broker before the expiration of this session timeout, then the broker will remove this consumer from the group and initiate a rebalance
 			sessionTimeout: 30000,
 			// The maximum time that the coordinator will wait for each member to rejoin when rebalancing the group

--- a/config/local.js
+++ b/config/local.js
@@ -1,3 +1,11 @@
+/**
+ * This config overrides any defaults. Specify any values here that you want to hardcode
+ * for this application or required ENV variables that will be merged.
+ *
+ * There is no way to check these values are ENV placeholders so if you set something here
+ * and there is no corresponded ENV value, the placeholder will still be used over
+ * anything in default config.
+ */
 module.exports = {
 	kafka: {
 		config: {

--- a/src/application/services/consumers/consumer.class.ts
+++ b/src/application/services/consumers/consumer.class.ts
@@ -1,7 +1,7 @@
 import Debug from 'debug';
 import { Consumer } from 'kafkajs';
 import { Service } from '../service.class';
-import { Application, ConsumerMessageCallback, ConsumerServiceOptions } from '../../../types/types';
+import { Application, ConsumerBatchCallback, ConsumerMessageCallback, ConsumerServiceOptions } from '../../../types/types';
 
 const debug = Debug('metamorphosis:app:consumer');
 
@@ -78,4 +78,6 @@ export class ConsumerService extends Service {
 	getTopic = (): string => this.options.topic;
 
 	getMessageHandler = (): ConsumerMessageCallback => this.options.messageHandler || (async (): Promise<void> => undefined);
+
+	getBatchHandler = (): ConsumerBatchCallback | undefined => this.options.batchHandler;
 }

--- a/src/application/services/consumers/consumer.class.ts
+++ b/src/application/services/consumers/consumer.class.ts
@@ -47,6 +47,7 @@ export class ConsumerService extends Service {
 		await this.getConsumer().connect();
 		await this.getConsumer().subscribe({
 			topic,
+			fromBeginning: !!this.options.fromBeginning,
 		});
 
 		Debug('metamorphosis:runtime')(

--- a/src/application/services/consumers/default/default.service.ts
+++ b/src/application/services/consumers/default/default.service.ts
@@ -19,14 +19,15 @@ export default function(app: Application): void {
 
 	// Get default consumer topic
 	const {
-		consumer: { topic: defaultTopic },
-	} = kafkaSettings || { consumer: { topic: {} } };
+		consumer: { topic: defaultTopic, fromBeginning },
+	} = kafkaSettings || { consumer: {} };
 
 	const options: DefaultConsumerServiceOptions = {
 		id: 'consumer',
 		type: 'consumer',
 		kafkaSettings,
 		topic: defaultTopic,
+		fromBeginning: fromBeginning,
 	};
 
 	// Initialize our service with any options it requires

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 import fastify, { HTTPMethod, RequestHandler } from 'fastify';
-import { KafkaConfig, ConsumerConfig, ProducerConfig, Message, Kafka, RecordMetadata } from 'kafkajs';
+import { KafkaConfig, ConsumerConfig, EachBatchPayload, ProducerConfig, Message, Kafka, RecordMetadata } from 'kafkajs';
 import { PoolConnection, ConnectionOptions, RowDataPacket, OkPacket, FieldPacket, QueryOptions } from 'mysql2';
 import { EventEmitter } from 'events';
 import * as http from 'http';
@@ -199,6 +199,7 @@ export declare class DefaultProducerService<T = any> extends ProducerService<T> 
 export interface ConsumerServiceOptions extends ServiceOptions {
 	topic: string;
 	messageHandler?: ConsumerMessageCallback;
+	batchHandler?: ConsumerBatchCallback;
 }
 
 export declare class ConsumerService<T = any> extends Service<T> implements ServiceMethods<T> {
@@ -312,6 +313,8 @@ export interface ProduceKafkaMessage {
 	timestamp?: number;
 	headers?: {};
 }
+
+export type ConsumerBatchCallback = (payload: EachBatchPayload) => Promise<void>;
 
 export type ConsumerMessageCallback = (message: Message) => Promise<void>;
 


### PR DESCRIPTION
- Fix issue with `DefaultConsumer` which was catching errors, but this means offsets would actually be committed on failure to process message. The Runner class that processes each batch handles errors already so simply run our method and resolve offset if it doesn't throw an error.
- Allow overriding the default `eachBatch()` method on consumer via `Consumer::setConfig()`
- Set `fromBeginning` via Config or using `Consumer::setConfig()` to allow for reading from the beginning of a topic for a new consumer group instead of new messages only. 