### PR TITLE
Updated HTTP server Producer Route with JSON big and buffered message

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -74,7 +74,7 @@ module.exports = {
 		},
 	},
 	server: {
-		log: false,
+		logger: false,
 		port: 3000,
 		address: '0.0.0.0',
 		opts: {},

--- a/config/local.js
+++ b/config/local.js
@@ -36,7 +36,7 @@ module.exports = {
 	// 	},
 	// },
 	server: {
-		log: 'SERVER_LOGGING',
+		logger: 'SERVER_LOGGING',
 		port: 'SERVER_PORT',
 		address: 'SERVER_HOST',
 		opts: {},

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "debug": "^4.1.1",
     "dotenv": "^8.2.0",
     "fastify": "^2.11.0",
+    "json-bigint": "^0.3.0",
     "kafkajs": "^1.11.0",
     "lodash": "^4.17.15",
     "mysql2": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -843,6 +843,11 @@ before-after-hook@^2.0.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
   integrity sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
 
+bignumber.js@^7.0.0:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-7.2.1.tgz#80c048759d826800807c4bfd521e50edbba57a5f"
+  integrity sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==
+
 binary-extensions@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
@@ -3462,6 +3467,13 @@ jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
+
+json-bigint@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-0.3.0.tgz#0ccd912c4b8270d05f056fbd13814b53d3825b1e"
+  integrity sha1-DM2RLEuCcNBfBW+9E4FLU9OCWx4=
+  dependencies:
+    bignumber.js "^7.0.0"
 
 json-buffer@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
- Updated HTTP server Producer Route to produce buffered message instead of raw JSON string
- Added JSON-bigint package for producing messages to account for 64-bit integers that may get passed in from webhooks to avoid JS limitations
- Updated server logging config param to 'logger'
- Changed request body in HTTP producer route to verbose debug to avoid duplicate output with Producer debugging unless desired