### PR TITLE
Added compression config for producers and Snappy plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "fastify": "^2.11.0",
     "json-bigint": "^0.3.0",
     "kafkajs": "^1.11.0",
+    "kafkajs-snappy": "^1.1.0",
     "lodash": "^4.17.15",
     "mysql2": "^2.1.0",
     "winston": "^3.2.1"

--- a/src/application/services/producers/default/default.service.ts
+++ b/src/application/services/producers/default/default.service.ts
@@ -18,7 +18,7 @@ export default function(app: Application): void {
 
 	// Get default consumer topic
 	const {
-		producer: { topic: defaultTopic },
+		producer: { topic: defaultTopic, compression },
 	} = kafkaSettings || { producer: { topic: {} } };
 
 	const options: DefaultProducerServiceOptions = {
@@ -26,6 +26,7 @@ export default function(app: Application): void {
 		type: 'producer',
 		kafkaSettings,
 		topic: defaultTopic,
+		compression,
 	};
 
 	// Initialize our service with any options it requires

--- a/src/application/services/producers/producer.class.ts
+++ b/src/application/services/producers/producer.class.ts
@@ -1,5 +1,15 @@
 import Debug from 'debug';
-import { CompressionTypes, Message, Producer, ProducerRecord, RecordMetadata, ProducerBatch, TopicMessages } from 'kafkajs';
+import {
+	CompressionCodecs,
+	CompressionTypes,
+	Message,
+	Producer,
+	ProducerRecord,
+	RecordMetadata,
+	ProducerBatch,
+	TopicMessages,
+} from 'kafkajs';
+import SnappyCodec from 'kafkajs-snappy';
 import { Service } from '../service.class';
 import { Application, ProducerServiceOptions } from '../../../types/types';
 
@@ -33,6 +43,9 @@ export class ProducerService extends Service {
 
 		// Initialize producer
 		this.producer = this.getClient().producer(producerConfig);
+
+		// Add support for Snappy compression
+		CompressionCodecs[CompressionTypes.Snappy] = SnappyCodec;
 	}
 
 	/**
@@ -67,7 +80,7 @@ export class ProducerService extends Service {
 			messages,
 			acks: this.options.acks || -1, // Default is -1 "all leaders must acknowledge"
 			timeout: this.options.timeout || 30000,
-			compression: CompressionTypes.None,
+			compression: this.options.compression || CompressionTypes.None,
 		};
 
 		try {
@@ -93,7 +106,7 @@ export class ProducerService extends Service {
 			topicMessages,
 			acks: this.options.acks || -1, // Default is -1 "all leaders must acknowledge"
 			timeout: this.options.timeout || 30000,
-			compression: CompressionTypes.None,
+			compression: this.options.compression || CompressionTypes.None,
 		};
 
 		try {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -168,6 +168,7 @@ export declare class DefaultService<T = any> extends Service<T> implements Servi
 export interface ProducerServiceOptions extends ServiceOptions {
 	topic: string;
 	multiTopic?: string[];
+	compression?: number;
 }
 
 export declare class ProducerService<T = any> extends Service<T> implements ServiceMethods<T> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3181,6 +3181,13 @@ json5@^2.1.1, json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
+kafkajs-snappy@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/kafkajs-snappy/-/kafkajs-snappy-1.1.0.tgz#0bc20fb069147b00b34b64f7fb2394e8b2b9747d"
+  integrity sha512-M4h2WhlxhXmR64z8nwzfGa1Dhhz78vykRfySRL8tuYQ8e6JSOuclbF2FJ8jeMJP3EZWw3uhjvwHlz7Ucu3UdWA==
+  dependencies:
+    snappyjs "^0.6.0"
+
 kafkajs@^1.11.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/kafkajs/-/kafkajs-1.12.0.tgz#50ad336baee95f3324af8ae8df6fadc96e07c613"
@@ -5053,6 +5060,11 @@ sliced@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sliced/-/sliced-1.0.1.tgz#0b3a662b5d04c3177b1926bea82b03f837a2ef41"
   integrity sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E=
+
+snappyjs@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/snappyjs/-/snappyjs-0.6.0.tgz#2bd550e5767fb1bc28140bf8d53bf9590576a386"
+  integrity sha512-VTBBV4C9SHLuNEw8qrxw3EnkYmzwe8ml5VA8zS6XChr/yQ/CEDobofC6j4S25QJQR0htRGD68Oh4TZxv/mpf7w==
 
 sonic-boom@^0.7.5:
   version "0.7.7"


### PR DESCRIPTION
- Configure `compression` in the `kafka.producer` config as an enum `CompressionTypes` imported from **kafkajs**
- Available compression types are `GZIP` and `Snappy` (installed as plugin package **kafkajs-snappy**). `LZ4` is no supported at this time to keep dependencies down.

Closes #15