### PR TITLE
Mysql insert

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Copy example `.env` and replace values with your own
 cp .env.example .env
 ```
 
-| Option               | Description                                                                  | Default                      |
-| -------------------- | ---------------------------------------------------------------------------- | ---------------------------- |
-| KAFKA_BROKERS        | Comma-delimited string of brokers e.g. `10.10.10.1:9092,10.10.10.2:9092,...` | localhost:9092               |
-| KAFKA_CLIENT_ID      | Unique ID used by consumers and producers in this app                        | metamorphosis                |
-| KAFKA_TOPIC_CONSUMER | Topic to read from for a single-topic consumer app                           | metamorphosis.test           |
-| KAFKA_TOPIC_PRODUCER | Topic to write to for a single-topic producer app                            | metamorphosis.test           |
-| CONSUMER_GROUP_ID    | Group name responsible for tracking offsets on a consumer                    | metamorphosis-consumer-group |
+| Option               | Description                                                                                              | Default                      |
+| -------------------- | -------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| KAFKA_BROKERS        | Comma-delimited string of brokers e.g. `10.10.10.1:9092,10.10.10.2:9092,...`                             | localhost:9092               |
+| KAFKA_CLIENT_ID      | Unique ID used by consumers and producers in this app                                                    | metamorphosis                |
+| KAFKA_TOPIC_CONSUMER | Topic to read from for a single-topic consumer app                                                       | metamorphosis.test           |
+| KAFKA_TOPIC_PRODUCER | Topic to write to for a single-topic producer app                                                        | metamorphosis.test           |
+| CONSUMER_GROUP_ID    | Group name responsible for tracking offsets on a consumer. This should be unique for every consumer app. | metamorphosis-consumer-group |
 
 # Usage
 

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "kafkajs": "^1.11.0",
     "kafkajs-snappy": "^1.1.0",
     "lodash": "^4.17.15",
+    "moment-timezone": "^0.5.28",
     "mysql2": "^2.1.0",
     "winston": "^3.2.1"
   },

--- a/src/application/services/producers/producer.class.ts
+++ b/src/application/services/producers/producer.class.ts
@@ -1,15 +1,5 @@
 import Debug from 'debug';
-import {
-	CompressionCodecs,
-	CompressionTypes,
-	Message,
-	Producer,
-	ProducerRecord,
-	RecordMetadata,
-	ProducerBatch,
-	TopicMessages,
-} from 'kafkajs';
-import SnappyCodec from 'kafkajs-snappy';
+import { CompressionTypes, Message, Producer, ProducerRecord, RecordMetadata, ProducerBatch, TopicMessages } from 'kafkajs';
 import { Service } from '../service.class';
 import { Application, ProducerServiceOptions } from '../../../types/types';
 
@@ -43,9 +33,6 @@ export class ProducerService extends Service {
 
 		// Initialize producer
 		this.producer = this.getClient().producer(producerConfig);
-
-		// Add support for Snappy compression
-		CompressionCodecs[CompressionTypes.Snappy] = SnappyCodec;
 	}
 
 	/**

--- a/src/application/services/service.class.ts
+++ b/src/application/services/service.class.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import Debug from 'debug';
-import { Kafka } from 'kafkajs';
+import { CompressionCodecs, CompressionTypes, Kafka } from 'kafkajs';
+import SnappyCodec from 'kafkajs-snappy';
 import { get } from 'lodash';
 import deepmerge from 'deepmerge';
 import { Application, Id, ServiceMethods, ServiceOptions, ServiceTypes } from '../../types/types';
@@ -35,6 +36,9 @@ export class Service<T = any> implements ServiceMethods<T> {
 				const brokerString: string = brokers!.toString();
 				config.brokers = brokerString.split(',');
 			}
+
+			// Add support for Snappy compression
+			CompressionCodecs[CompressionTypes.Snappy] = SnappyCodec;
 
 			debug(`Setting Kafka client`, config);
 

--- a/src/database-adapters/adapter.ts
+++ b/src/database-adapters/adapter.ts
@@ -1,4 +1,6 @@
-import { DatabaseSetup, DatabaseConfig } from '../types/types';
+import { get } from 'lodash';
+import deepmerge from 'deepmerge';
+import { DatabaseSetup, DatabaseConfig, GenericOptions } from '../types/types';
 
 export class DatabaseBaseClient implements DatabaseSetup {
 	/** Database connection string */
@@ -7,13 +9,27 @@ export class DatabaseBaseClient implements DatabaseSetup {
 	/** Database connection config */
 	connectionConfig?: any;
 
+	/** General options that are not adapter specific */
+	options: GenericOptions;
+
 	// /** Database connection object */
 	// connection: any;
 
 	constructor(databaseConfig: DatabaseConfig) {
-		const { connectionString, config } = databaseConfig;
+		const { connectionString, config, options } = databaseConfig;
 
 		this.connectionString = connectionString;
 		this.connectionConfig = config;
+
+		this.options = options || {};
 	}
+
+	getConfig = (key?: string): any => (this.options && key ? get(this.options, key) : this.options);
+
+	setConfig = (overrideOptions: GenericOptions): this => {
+		this.options = deepmerge(this.options, overrideOptions);
+		return this;
+	};
+
+	getTimezone = (): string | undefined => this.options.timeZone;
 }

--- a/src/database-adapters/mysql-pool/mysql-pool.class.ts
+++ b/src/database-adapters/mysql-pool/mysql-pool.class.ts
@@ -1,9 +1,13 @@
 import Debug from 'debug';
 import mysqlClient from 'mysql2/promise';
+import moment from 'moment-timezone';
 import { DatabaseBaseClient } from '../adapter';
-import { DatabaseClient, DatabaseConfig } from '../../types/types';
+import { DatabaseClient, DatabaseConfig, SqlInsertValues, GenericOptions } from '../../types/types';
 
-const debug = Debug('metamorphosis:mysql');
+const debug = Debug('metamorphosis:database');
+const debugDebug = Debug('metamorphosis:database:debug');
+const debugVerbose = Debug('metamorphosis:database:verbose');
+const debugError = Debug('metamorphosis:error');
 
 export class DatabaseMysqlPoolClient extends DatabaseBaseClient implements DatabaseClient {
 	connection!: any;
@@ -21,8 +25,27 @@ export class DatabaseMysqlPoolClient extends DatabaseBaseClient implements Datab
 			// this.connection = await pool.getConnection();
 
 			debug('Connected to MySql Pool');
+
+			// Set timezone for client if passed to allow for proper TIMESTAMP data
+			const timeZone = this.getTimezone();
+			let tzOffset;
+			if (timeZone) {
+				tzOffset = moment()
+					.tz(this.getTimezone())
+					.format('Z');
+
+				debug(`Setting timezone to ${timeZone} (${tzOffset})`);
+			} else {
+				tzOffset = moment().format('Z');
+
+				debug(`Setting timezone to server default (${tzOffset})`);
+			}
+
+			// Set time_zone for session
+			await this.connection.query('SET SESSION time_zone=?;', [tzOffset]);
 		} catch (err) {
-			console.error('MySql connection error:', err);
+			debugError('MySql connection error', err);
+			throw err;
 		}
 
 		return this;
@@ -42,7 +65,8 @@ export class DatabaseMysqlPoolClient extends DatabaseBaseClient implements Datab
 	 * @param query
 	 */
 	async query(query: string, params: Array<any> | string = []): Promise<any> {
-		debug('query %s', mysqlClient.format(query, params));
+		// debugVerbose('Query: %s', mysqlClient.format(query, params));
+		debugDebug('Query: %s', query);
 
 		if (!query) {
 			return;
@@ -51,7 +75,8 @@ export class DatabaseMysqlPoolClient extends DatabaseBaseClient implements Datab
 		try {
 			return await this.connection.query(query, params);
 		} catch (err) {
-			console.error(err.message);
+			debugError(err.message);
+			throw err;
 		}
 	}
 
@@ -62,7 +87,8 @@ export class DatabaseMysqlPoolClient extends DatabaseBaseClient implements Datab
 	 * @param params
 	 */
 	async execute(query: string, params: Array<any> | string = []): Promise<any> {
-		debug('prepared query %s', mysqlClient.format(query, params));
+		// debugVerbose('Prepared query: %s', mysqlClient.format(query, params));
+		debugDebug('Prepared query: %s', query);
 
 		if (!query) {
 			return;
@@ -71,7 +97,61 @@ export class DatabaseMysqlPoolClient extends DatabaseBaseClient implements Datab
 		try {
 			return await this.connection.execute(query, params);
 		} catch (err) {
-			console.error(err.message);
+			debugError(err.message);
+			throw err;
 		}
+	}
+
+	/**
+	 * Insert a record into a database table
+	 *
+	 * As of right now, we explicitly prevent the ability to insert into different databases on the same connection.
+	 * This may change in a future release, but likely points to an issue with your consumer application design if
+	 * it is modifying data in multiple database.
+	 *
+	 * @param insertData
+	 * @param tableName
+	 * @param insertOptions
+	 */
+	async insert(insertData: SqlInsertValues, tableName?: string, insertOptions?: GenericOptions): Promise<any> {
+		const { database: dbName } = this.connectionConfig;
+
+		// Get table name and remove database prefix if specific in tableName to avoid cross-database inserts
+		const dbTableName = (tableName || '').split('.').pop();
+
+		const {
+			insert: { mode },
+			// pk,
+		} = insertOptions || { insert: {} };
+
+		// Throw error if no table passed nor found in config
+		if (!dbTableName) {
+			throw new Error(`Cannot insert into database without table specifcied`);
+		}
+
+		// Since insert records in array must contain the same fields, get the schema from the first row
+		const fields = Object.keys(insertData[0]);
+
+		// Create array of rowValues in the same order as fields to ensure identical ordering of all row values for multiple inserts
+		const rowValues: any[][] = insertData.map(row => {
+			// Remove object keys not in fields array
+			row = Object.keys(row)
+				.filter(field => fields.includes(field))
+				.reduce((obj, field) => ({ ...obj, [field]: row[field] }), {});
+
+			// Ensure fields are in same order as fields
+			return fields.map(field => row[field] || null);
+		});
+
+		// Build SQL insert
+		const insertSql = `insert ${mode === 'insertignore' ? 'ignore' : ''} into ${dbName}.${dbTableName} (${fields.join(',')}) VALUES ?`;
+
+		// TODO: This needs a lot of work to handle multiple values being passed
+		// if (mode === 'upsert') {
+		// 	insertSql += ` on duplicate key update set ?`;
+		// }
+
+		// Run SQL insert
+		return await this.query(insertSql, [rowValues]);
 	}
 }

--- a/src/database-adapters/mysql-pool/mysql-pool.ts
+++ b/src/database-adapters/mysql-pool/mysql-pool.ts
@@ -2,7 +2,7 @@ import Debug from 'debug';
 import { DatabaseMysqlPoolClient } from './mysql-pool.class';
 import { Application, GenericOptions, InitFunction, DatabaseConfig } from '../../types/types';
 
-const debugErrors = Debug('metamorphosis.errors');
+const debugError = Debug('metamorphosis:error');
 
 export default function init(opts?: GenericOptions): InitFunction {
 	return (app?: Application): void => {
@@ -10,28 +10,30 @@ export default function init(opts?: GenericOptions): InitFunction {
 		if (!app) {
 			return;
 		}
-		const databaseConfig = app.get('config.database');
+		const configDb = app.get('config.database');
 
 		const {
+			options: configOptions,
 			mysql: { config: mysqlPoolConfig },
-		} = databaseConfig || { mysql: { config: {} } };
+		} = configDb || { mysql: { config: {} } };
 
 		// Ensure the minimum values are set to create MySQL Pool
 		const hasRequriedProps = ['database', 'password', 'user'].reduce((i, j) => i && j in mysqlPoolConfig, true);
 
 		if (!hasRequriedProps) {
-			debugErrors(`Missing required properties to create Mysql connection`, mysqlPoolConfig);
+			debugError(`Missing required properties to create Mysql connection`, mysqlPoolConfig);
 			return;
 		}
 
-		const options: DatabaseConfig = {
+		const databaseConfig: DatabaseConfig = {
 			config: mysqlPoolConfig,
 			...opts,
+			options: configOptions,
 		};
 
 		// Initialize our service with any options it requires
 		// TODO: use mixin to add database method to app object and possibly move this to main index for this plugin
 		// so user would init the generic database adapater index.ts and specify which adapater(s)
-		app.set('database', new DatabaseMysqlPoolClient(options));
+		app.set('database', new DatabaseMysqlPoolClient(databaseConfig));
 	};
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -47,6 +47,8 @@ export type NullableId = Id | null;
 
 export type GenericOptions = { [key: string]: any };
 
+export type GenericObject = { [key: string]: any };
+
 export interface ServiceMethods<T> {
 	[key: string]: any;
 
@@ -272,6 +274,7 @@ export interface ServerHttpRoute {
 export interface DatabaseConfig {
 	connectionString?: string;
 	config?: PoolConnection;
+	options?: GenericOptions;
 }
 
 export interface DatabaseSetup {
@@ -377,3 +380,5 @@ export interface Connection extends EventEmitter {
 export interface PoolConnection extends Connection {
 	release(): void;
 }
+
+export type SqlInsertValues = { [key: string]: any }[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -3683,6 +3683,18 @@ mocha@^7.0.1:
     yargs-parser "13.1.2"
     yargs-unparser "1.6.0"
 
+moment-timezone@^0.5.28:
+  version "0.5.28"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.28.tgz#f093d789d091ed7b055d82aa81a82467f72e4338"
+  integrity sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0":
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
- Added MySql pool adapter insert method which accepts an array of key/value fields to insert into a table
- Limited options at this time, but you can toggle between the `insert.mode` with `insert`, `insertignore`. Planning to add `upsert` and `update` to mirror Kafka Connect JDBC connector options.
- Timezone support through [moment-timezone](https://github.com/moment/moment-timezone/) adds support for writing TIMESTAMP fields as strings but storing in the proper timezone if the client is running on a different timezone than the server.