### PR TITLE
Sink MySql consumer

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -46,6 +46,25 @@ module.exports = {
 			maxBytes: 10485760,
 			// The maximum amount of time in milliseconds the server will block before answering the fetch request if there isn’t sufficient data to immediately satisfy the requirement given by minBytes
 			maxWaitTimeInMs: 5000,
+			// Sink consumer config
+			sink: {
+				insert: {
+					mode: 'insert', // insert|insertignore|upsert|update
+				},
+				table: {
+					name: '', // If set, all records will be written to this table regardless of data in key or value.
+					topicPrefix: '', // If set, will assume table name whatever follows the prefix in the consumed topic name. So topic `stream.event.production.orders` will write to the `orders` table.
+				},
+				// TODO: Finish these settings
+				// pk: {
+				// 	mode: '', // Empty for none, `record_value`, `record_key`
+				// 	fields: '', // List of comma-separated primary key field names
+				// },
+				fields: {
+					whitelist: '', // List of comma-separated record value field names. If empty, all fields from the record value are utilized, otherwise used to filter to the desired fields.
+					fromUnixtime: '', // List of comma-separated field names to convert from unix timestamps to MySQL dates.
+				},
+			},
 		},
 		producer: {
 			// Default producer topic

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "kafkajs": "^1.11.0",
     "kafkajs-snappy": "^1.1.0",
     "lodash": "^4.17.15",
+    "moment": "^2.24.0",
     "moment-timezone": "^0.5.28",
     "mysql2": "^2.1.0",
     "winston": "^3.2.1"

--- a/src/application/index.ts
+++ b/src/application/index.ts
@@ -3,7 +3,7 @@ import { Application } from '../types/types';
 
 // Export barrel objects as well as individual service so we can import all or specific services in our application
 export { default as services } from './services';
-export { default as consumers, consumer } from './services/consumers';
+export { default as consumers, consumer, sinkMysqlConsumer } from './services/consumers';
 export { default as producers, producer } from './services/producers';
 
 // interface Metamophosis {

--- a/src/application/services/consumers/index.ts
+++ b/src/application/services/consumers/index.ts
@@ -1,10 +1,12 @@
 import { Application } from '../../../types/types';
 import consumer from './default/default.service';
+import sinkMysqlConsumer from './sink-mysql/sink-mysql.service';
 
 // Export individual consumers so they can be loaded explicitly
-export { consumer };
+export { consumer, sinkMysqlConsumer };
 
 export default function(app: Application): void {
 	// Import and configure all consumers here
 	app.configure(consumer);
+	app.configure(sinkMysqlConsumer);
 }

--- a/src/application/services/consumers/sink-mysql/sink-mysql.class.ts
+++ b/src/application/services/consumers/sink-mysql/sink-mysql.class.ts
@@ -1,0 +1,189 @@
+import Debug from 'debug';
+import moment from 'moment';
+import { ConsumerService } from '../consumer.class';
+import { parseValueAsArray } from '../../../../utils';
+import { Application, GenericObject, SinkMysqlConsumerServiceOptions } from '../../../../types/types';
+
+const debug = Debug('metamorphosis:app:consumer:sink-mysql');
+const debugError = Debug('metamorphosis:error');
+const debugVerbose = Debug('metamorphosis:app:consumer:sink-mysql:verbose');
+
+export class SinkMysqlConsumerService extends ConsumerService {
+	/** Service options for this consumer */
+	sinkMysqlConsumerOptions: SinkMysqlConsumerServiceOptions;
+
+	/** MySql client */
+	database;
+
+	/**
+	 * DefaultConsumerService constructor
+	 *
+	 * @param options
+	 * @param app
+	 */
+	constructor(options: SinkMysqlConsumerServiceOptions, app: Application) {
+		// Instantiate BaseConsumer
+		super(options, app);
+
+		this.sinkMysqlConsumerOptions = options;
+
+		this.database = app.get('database');
+	}
+
+	/**
+	 * Start consumer, subscribe to our topic and listen for batches of messages.
+	 * Run message callback on every message recieved and write any errors to a new Kafka topic.
+	 */
+	async start(): Promise<this> {
+		// Connect to  MySql
+		await this.database.connect();
+
+		// Run initial consumer connect and subscribe
+		await super.start();
+
+		/**
+		 * Batch message
+		 *
+		 * {
+		 *		topic: batch.topic,
+		 *		partition: batch.partition,
+		 *		highWatermark: batch.highWatermark,
+		 *		message: {
+		 *			offset: message.offset,
+		 *			key: message.key
+		 *				? message.key.toString()
+		 *				: null,
+		 *			value: message.value
+		 *				? message.value.toString()
+		 *				: null,
+		 *			headers: message.headers
+		 *				? message.headers.toString()
+		 *				: null,
+		 *		},
+		 *	}
+		 */
+		await this.getConsumer().run({
+			// Allow batch to fail in the middle without committing all offsets
+			eachBatchAutoResolve: false,
+			eachBatch: async ({ batch, resolveOffset, heartbeat, isRunning, isStale }): Promise<void> => {
+				debug(`Consuming batch of ${batch.messages.length} messages`);
+
+				// Array of batched messages that will be inserted after entire batch is processed
+				const batchInsertValues: any[] = [];
+
+				// Keep track of fields since batch inserts must all have the same columns
+				let batchFields: string[] = [];
+
+				const { topic: batchTopic, messages } = batch;
+
+				for (const message of messages) {
+					if (!isRunning() || isStale()) break;
+
+					// Extract message value from Kafka message
+					const { value: messageValueBuffer } = message || {};
+
+					// Kafka message value is a Buffer containing a JSON string so decode
+					const messageValue = messageValueBuffer && JSON.parse(messageValueBuffer.toString());
+
+					let { values } = messageValue || {};
+					const { table, pk, fields } = messageValue || {};
+
+					// If message does not contain `values` key then assume the message value is a struct
+					// containing all keys and values to insert.
+					if (!values) {
+						values = messageValue;
+					}
+
+					// Skip empty records
+					if (!values) {
+						resolveOffset(message.offset);
+						continue;
+					}
+
+					// Get table name from message or config
+					const {
+						table: { name: configTableName, topicPrefix: configTableTopicPrefix },
+					} = this.sinkMysqlConsumerOptions;
+
+					// Order of precedence is table specified in message, explicitly in app config, or as a pattern suffix to all consumed topics
+					const dbTable =
+						table || configTableName || (configTableTopicPrefix ? batchTopic.replace(configTableTopicPrefix, '') : null);
+
+					// Skip if no table can be derived
+					if (!dbTable) {
+						debugError('No table specificed for message:', messageValue);
+
+						resolveOffset(message.offset);
+						continue;
+					}
+
+					const {
+						fields: { whitelist, fromUnixtime },
+					} = this.sinkMysqlConsumerOptions;
+
+					// Get fields that should be allowed (use all keys if empty)
+					const whitelistFields = parseValueAsArray(whitelist);
+
+					// Get fields that are passed as unix timestamps but should be converted to MySql date format YYYY-MM-DD HH:mm:ss
+					const convertEpochFields = parseValueAsArray(fromUnixtime);
+
+					// Get field schema if not yet set for batch
+					if (!batchFields.length) {
+						batchFields = whitelistFields || Object.keys(values);
+					}
+
+					const rowData: GenericObject = Object.keys(values)
+						// Only allow fields that exist in the batch which will be fields in the whitelist config is set,
+						// otherwise allow all keys from the first valid message in the batch
+						.filter(key => batchFields.includes(key))
+						// Convert fields and values back into key/value object for sink
+						.reduce((obj, key) => {
+							let fieldValue = values[key];
+
+							// Convert unix timestamps into MySql dates for specified fields.
+							// This will convert to the local timezone which will be set on the MySQL insert
+							if (!!convertEpochFields && convertEpochFields.includes(key)) {
+								fieldValue = moment.unix(fieldValue).format('YYYY-MM-DD HH:mm:ss');
+							}
+
+							// Add value to final object
+							obj[key] = fieldValue;
+							return obj;
+						}, {});
+
+					// See if batch insert already has rows for current table and either add or append
+					const tableIndex = batchInsertValues.findIndex(f => f.table === dbTable);
+
+					if (tableIndex === -1) {
+						batchInsertValues.push({
+							table: dbTable,
+							values: [rowData],
+						});
+					} else {
+						batchInsertValues[tableIndex].values = [...batchInsertValues[tableIndex].values, rowData];
+					}
+
+					resolveOffset(message.offset);
+					await heartbeat();
+				}
+
+				// TODO: What if the batch fails mid-loop? Are the resolved offsets committed? If so the producer would not finish so ignore marking those as read
+
+				// Run SQL inserts for every group of table + values
+				for (const tableInserts of batchInsertValues) {
+					const { table, values } = tableInserts;
+
+					const { insert } = this.sinkMysqlConsumerOptions || {};
+
+					const result = await this.database.insert(values, table, {
+						...(insert && { insert }),
+					});
+
+					debugVerbose('Result: ', result);
+				}
+			},
+		});
+
+		return this;
+	}
+}

--- a/src/application/services/consumers/sink-mysql/sink-mysql.class.ts
+++ b/src/application/services/consumers/sink-mysql/sink-mysql.class.ts
@@ -101,9 +101,8 @@ export class SinkMysqlConsumerService extends ConsumerService {
 					}
 
 					// Get table name from message or config
-					const {
-						table: { name: configTableName, topicPrefix: configTableTopicPrefix },
-					} = this.sinkMysqlConsumerOptions;
+					const { table: configTable } = this.sinkMysqlConsumerOptions || {};
+					const { name: configTableName, topicPrefix: configTableTopicPrefix } = configTable || {};
 
 					// Order of precedence is table specified in message, explicitly in app config, or as a pattern suffix to all consumed topics
 					const dbTable =

--- a/src/application/services/consumers/sink-mysql/sink-mysql.service.ts
+++ b/src/application/services/consumers/sink-mysql/sink-mysql.service.ts
@@ -1,0 +1,43 @@
+// Initializes the `defaultConsumer` service
+import { SinkMysqlConsumerService } from './sink-mysql.class';
+import { mysqlPoolDatabaseAdapater } from '../../../../database-adapters/';
+import { Application, ConsumerTypes, SinkMysqlConsumerServiceOptions } from '../../../../types/types';
+
+// import hooks from './default.hooks';
+
+// Add this service to the service type index
+declare module '../../../../types/types' {
+	interface ConsumerTypes {
+		SinkMysqlConsumer: SinkMysqlConsumerService;
+	}
+}
+
+export default function(app: Application): void {
+	// Get Kafka config
+	const kafkaSettings = app.get('config.kafka');
+
+	// Get default consumer topic
+	const {
+		consumer: { topic: defaultTopic, fromBeginning, sink = {} },
+	} = kafkaSettings || { consumer: {} };
+
+	const options: SinkMysqlConsumerServiceOptions = {
+		id: 'sinkMysqlConsumer',
+		type: 'consumer',
+		kafkaSettings,
+		topic: defaultTopic,
+		fromBeginning: fromBeginning,
+		...sink,
+	};
+
+	// Set up MySql Pool adapater which will handdle the setup and validation of its own config
+	app.configure(mysqlPoolDatabaseAdapater());
+
+	// Initialize our service with any options it requires
+	app.use('sinkMysqlConsumer', new SinkMysqlConsumerService(options, app));
+
+	// Get our initialized service so that we can register hooks
+	// const service = app.service('sinkMysqlConsumer');
+
+	// service.hooks(hooks);
+}

--- a/src/database-adapters/mysql-pool/mysql-pool.class.ts
+++ b/src/database-adapters/mysql-pool/mysql-pool.class.ts
@@ -28,18 +28,13 @@ export class DatabaseMysqlPoolClient extends DatabaseBaseClient implements Datab
 
 			// Set timezone for client if passed to allow for proper TIMESTAMP data
 			const timeZone = this.getTimezone();
-			let tzOffset;
-			if (timeZone) {
-				tzOffset = moment()
-					.tz(this.getTimezone())
-					.format('Z');
+			const tzOffset = timeZone
+				? moment()
+						.tz(this.getTimezone())
+						.format('Z')
+				: moment().format('Z');
 
-				debug(`Setting timezone to ${timeZone} (${tzOffset})`);
-			} else {
-				tzOffset = moment().format('Z');
-
-				debug(`Setting timezone to server default (${tzOffset})`);
-			}
+			debug(`Setting timezone to ${timeZone || 'server default'} (${tzOffset})`);
 
 			// Set time_zone for session
 			await this.connection.query('SET SESSION time_zone=?;', [tzOffset]);

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -213,6 +213,8 @@ export declare class ConsumerService<T = any> extends Service<T> implements Serv
 
 export type DefaultConsumerServiceOptions = ConsumerServiceOptions;
 
+export type SinkMysqlConsumerServiceOptions = ConsumerServiceOptions;
+
 export declare class DefaultConsumerService<T = any> extends ConsumerService<T> implements InternalServiceMethods<T> {
 	options: DefaultConsumerServiceOptions;
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 import parseEnvValue from './parse-env-value';
 import parseMessageValue from './parse-message-value';
+import parseValueAsArray from './parse-value-as-array';
 
-export { parseEnvValue, parseMessageValue };
+export { parseEnvValue, parseMessageValue, parseValueAsArray };

--- a/src/utils/parse-value-as-array.ts
+++ b/src/utils/parse-value-as-array.ts
@@ -1,0 +1,35 @@
+/**
+ * Similar to parseEnvValue except decidely converts all comma-delimited strings to arrays
+ *
+ * @param value
+ */
+const parseValueAsArray = (value: string | any[]): any => {
+	// Return if undefined
+	if (!value === undefined) {
+		return;
+	}
+
+	// Already an array
+	if (Array.isArray(value)) {
+		return value;
+	}
+
+	// Boolean
+	if (value.toString().toLowerCase() === 'true' || value.toString().toLowerCase() === 'false') {
+		return value.toString().toLowerCase() === 'true';
+	}
+
+	// Number
+	if (!isNaN(Number(value))) {
+		return Number(value);
+	}
+
+	// Comma-separated string
+	if (value.indexOf(',') !== -1) {
+		return value.split(',').map(parseValueAsArray);
+	}
+
+	return value;
+};
+
+export default parseValueAsArray;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3690,7 +3690,7 @@ moment-timezone@^0.5.28:
   dependencies:
     moment ">= 2.9.0"
 
-"moment@>= 2.9.0":
+"moment@>= 2.9.0", moment@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==


### PR DESCRIPTION
- Added new consumer to run as a MySql sink connector for inserting batch records into MySql DB which mimics the Confluent JDBC connector
- Requires `sink` configuration in `kafka.consumer` to specify `config.kafka.consumer.sink.table.name` or `config.kafka.consumer.sink.table.topicPrefix` **OR** the table must be specified in the message value for each message