### PR TITLE
Check env values for regex pattern

### DIFF
--- a/src/utils/parse-env-value.ts
+++ b/src/utils/parse-env-value.ts
@@ -1,3 +1,19 @@
+const isRegExp = (string: string): boolean => {
+	try {
+		return new Function(`
+            "use strict";
+            try {
+                new RegExp(${string});
+                return true;
+            } catch (e) {
+                return false;
+            }
+        `)();
+	} catch (e) {
+		return false;
+	}
+};
+
 const parseEnvValue = (value: string): any => {
 	// Return if undefined
 	if (!value === undefined) {
@@ -12,6 +28,17 @@ const parseEnvValue = (value: string): any => {
 	// Number
 	if (!isNaN(Number(value))) {
 		return Number(value);
+	}
+
+	// Regex
+	if (isRegExp(value)) {
+		const parts = value.split('/');
+		if (value[0] === '/' && parts.length >= 3) {
+			const option = parts[parts.length - 1];
+			const lastIndex = value.lastIndexOf('/');
+			const regex = value.substring(1, lastIndex);
+			return new RegExp(regex, option);
+		}
 	}
 
 	// Array


### PR DESCRIPTION
Allow passing a regular expression as a string via configuration module which will be converted to `new RegExp(regex, option)`

e.g. `/test-.*/i` would turn into `new RegExp('test-.*', 'i')`