### PR TITLE
Schema registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@kafkajs/confluent-schema-registry": "^1.0.6",
     "config": "^3.2.5",
     "debug": "^4.1.1",
     "dotenv": "^8.2.0",

--- a/src/application/registry/index.ts
+++ b/src/application/registry/index.ts
@@ -1,0 +1,3 @@
+import { KafkaSchemaRegistry } from './registry';
+
+export default KafkaSchemaRegistry;

--- a/src/application/registry/registry.ts
+++ b/src/application/registry/registry.ts
@@ -1,0 +1,37 @@
+import { SchemaRegistry } from '@kafkajs/confluent-schema-registry';
+import avro from 'avsc';
+import deepmerge from 'deepmerge';
+
+import longType from './types/long-type';
+import { SchemaRegistryAPIClientArgs, SchemaRegistryAPIClientOptions } from '@kafkajs/confluent-schema-registry/dist/api';
+
+export class KafkaSchemaRegistry extends SchemaRegistry {
+	constructor(schemaRegistryClient: SchemaRegistryAPIClientArgs, options?: SchemaRegistryAPIClientOptions | undefined) {
+		// // Merge any passed forSchemaOptions with custom registry for long Type.
+		// // Without specifying long Type then any BigInts from a database would be truncated and throw a precision error
+		// // https://github.com/kafkajs/confluent-schema-registry/issues/53
+		super(
+			schemaRegistryClient,
+			deepmerge(options || {}, {
+				registry: {
+					long: longType,
+				},
+				typeHook: (schema: any, opts: avro.ForSchemaOptions): any => {
+					let name = schema.name;
+					if (!name) {
+						return; // Not a named type, use default logic.
+					}
+					if (!~name.indexOf('.')) {
+						// We need to qualify the type's name.
+						const namespace = schema.namespace || opts.namespace;
+						if (namespace) {
+							name = `${namespace}.${name}`;
+						}
+					}
+					// Return the type registered with the same name, if any.
+					return opts.registry[name];
+				},
+			})
+		);
+	}
+}

--- a/src/application/registry/registry.ts
+++ b/src/application/registry/registry.ts
@@ -1,12 +1,12 @@
 import { SchemaRegistry } from '@kafkajs/confluent-schema-registry';
 import avro from 'avsc';
 import deepmerge from 'deepmerge';
+import { RegistryConfig, RegistryOptions } from '../../types/types';
 
 import longType from './types/long-type';
-import { SchemaRegistryAPIClientArgs, SchemaRegistryAPIClientOptions } from '@kafkajs/confluent-schema-registry/dist/api';
 
 export class KafkaSchemaRegistry extends SchemaRegistry {
-	constructor(schemaRegistryClient: SchemaRegistryAPIClientArgs, options?: SchemaRegistryAPIClientOptions | undefined) {
+	constructor(schemaRegistryClient: RegistryConfig, options?: RegistryOptions | undefined) {
 		// // Merge any passed forSchemaOptions with custom registry for long Type.
 		// // Without specifying long Type then any BigInts from a database would be truncated and throw a precision error
 		// // https://github.com/kafkajs/confluent-schema-registry/issues/53

--- a/src/application/registry/types/long-type.ts
+++ b/src/application/registry/types/long-type.ts
@@ -1,0 +1,16 @@
+import avro from 'avsc';
+
+export default avro.types.LongType.__with({
+	fromBuffer: (buf: { readBigInt64LE: () => any }) => buf.readBigInt64LE(),
+	toBuffer: (n: bigint) => {
+		const buf = Buffer.alloc(8);
+		buf.writeBigInt64LE(n);
+		return buf;
+	},
+	fromJSON: BigInt,
+	toJSON: Number,
+	isValid: (n: any) => typeof n == 'bigint',
+	compare: (n1: bigint, n2: bigint) => {
+		return n1 === n2 ? 0 : n1 < n2 ? -1 : 1;
+	},
+});

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -5,6 +5,8 @@ import { PoolConnection, ConnectionOptions, RowDataPacket, OkPacket, FieldPacket
 import { EventEmitter } from 'events';
 import { ApplicationServer } from '../server/server';
 import { DatabaseBaseClient } from '../database-adapters/adapter';
+import { SchemaRegistryAPIClientArgs, SchemaRegistryAPIClientOptions } from '@kafkajs/confluent-schema-registry/dist/api';
+import { isInteger } from 'lodash';
 
 // Make kafkajs types available
 export * from 'kafkajs';
@@ -248,10 +250,14 @@ export declare class MysqlConsumerService<T = any> extends ConsumerService<T> im
 // 	databaseClient?: string;
 // }
 
+export interface RegistryConfig extends SchemaRegistryAPIClientArgs {}
+export interface RegistryOptions extends SchemaRegistryAPIClientOptions {}
+
 export interface ApplicationKafkaSettings {
 	config: KafkaConfig;
 	consumer: ConsumerConfig;
 	producer: ProducerConfig;
+	registry?: RegistryConfig;
 }
 
 export interface ServerConfig {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,10 @@
   "compilerOptions": {
     "module": "commonjs",
     "lib": [
-      "es2015"
+      "dom",
+      "es2015",
+      "es5",
+      "es6"
     ],
     "declaration": true,
     "allowJs": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -214,6 +214,14 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
+"@kafkajs/confluent-schema-registry@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@kafkajs/confluent-schema-registry/-/confluent-schema-registry-1.0.6.tgz#e9b4d3ed63f139a4176e89484b7fd3359378f609"
+  integrity sha512-NrZL1peOIlmlLKvheQcJAx9PHdnc4kaW+9+Yt4jXUfbbYR9EFNCZt6yApI4SwlFilaiZieReM6XslWy1LZAvoQ==
+  dependencies:
+    avsc ">= 5.4.13 < 6"
+    mappersmith ">= 2.30.1 < 3"
+
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
@@ -763,6 +771,11 @@ auto-changelog@^1.16.2:
     parse-github-url "^1.0.2"
     regenerator-runtime "^0.13.5"
     semver "^6.3.0"
+
+"avsc@>= 5.4.13 < 6":
+  version "5.4.21"
+  resolved "https://registry.yarnpkg.com/avsc/-/avsc-5.4.21.tgz#eafaf5cbfd72bbc3d1bd82fc6bdeb7dda3ba8b2c"
+  integrity sha512-Vr733yyksCfwwXVZ6WjgttDF1TLlUeYWBJDHpO61qeOo6GnaIaVRiJ64ZgpwXfFtbPv1fCuLFV0qz++QUFCZPw==
 
 avvio@^6.3.1:
   version "6.4.1"
@@ -3530,6 +3543,11 @@ map-stream@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
   integrity sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=
+
+"mappersmith@>= 2.30.1 < 3":
+  version "2.33.3"
+  resolved "https://registry.yarnpkg.com/mappersmith/-/mappersmith-2.33.3.tgz#590dcda29e5d032ba5f9b8965fafd0893132af1f"
+  integrity sha512-MHroRYjz707UQrzg9Wk0llCkNM5nRnsYU5KXtIsXieL+UCFDDUm30Miq+XxRBXlSDJIZOWGBAaM6Q2+A4qXDew==
 
 markdown-escapes@^1.0.0:
   version "1.0.4"


### PR DESCRIPTION
Add support for Schema Registry via [kafkajs/confluent-schema-registry](https://github.com/kafkajs/confluent-schema-registry) when connecting to Kafka client. The primary function this streamlines vs loading this in the end application is the need for a custom long type of BigInt so that 64-bit integers are not truncated when loaded.

Our wrapper class does not add any additional functionality other than to autoload the long type on top of any passed client args / options. 