### PR TITLE
Remove mysql client from Debezium consumer

### DIFF
--- a/src/application/services/consumers/debezium-mysql/debezium-mysql.class.ts
+++ b/src/application/services/consumers/debezium-mysql/debezium-mysql.class.ts
@@ -10,9 +10,6 @@ export class DebeziumMysqlConsumerService extends ConsumerService {
 	/** Service options for this consumer */
 	debeziumMysqlConsumerOptions: DebeziumMysqlConsumerServiceOptions;
 
-	/** MySql client */
-	database;
-
 	/** Schema Registry client */
 	registry?: KafkaSchemaRegistry;
 
@@ -28,8 +25,6 @@ export class DebeziumMysqlConsumerService extends ConsumerService {
 
 		this.debeziumMysqlConsumerOptions = options;
 
-		this.database = app.get('database');
-
 		this.registry = app.get('registry');
 	}
 
@@ -42,9 +37,6 @@ export class DebeziumMysqlConsumerService extends ConsumerService {
 		if (!this.options.recordHandler) {
 			return;
 		}
-
-		// Connect to  MySql
-		await this.database.connect();
 
 		// Run initial consumer connect and subscribe
 		await super.start();
@@ -109,7 +101,7 @@ export class DebeziumMysqlConsumerService extends ConsumerService {
 							}, {});
 
 						// Run record handler callback
-						await this.options.recordHandler(this.database, name, source, op, before, after, changeData, tsMs);
+						await this.options.recordHandler(name, source, op, before, after, changeData, tsMs);
 
 						Debug('metamorphosis:app:consumer:debezium-mysql:verbose')('Resolving offset: %s', message.offset);
 

--- a/src/application/services/consumers/debezium-mysql/debezium-mysql.service.ts
+++ b/src/application/services/consumers/debezium-mysql/debezium-mysql.service.ts
@@ -1,6 +1,5 @@
 // Initializes the `defaultConsumer` service
 import { DebeziumMysqlConsumerService } from './debezium-mysql.class';
-import { mysqlPoolDatabaseAdapater } from '../../../../database-adapters';
 import { Application, ConsumerTypes, DebeziumMysqlConsumerServiceOptions } from '../../../../types/types';
 
 // import hooks from './default.hooks';
@@ -29,9 +28,6 @@ export default function(app: Application): void {
 		fromBeginning: fromBeginning,
 		recordHandler,
 	};
-
-	// Set up MySql Pool adapater which will handdle the setup and validation of its own config
-	app.configure(mysqlPoolDatabaseAdapater());
 
 	// Initialize our service with any options it requires
 	app.use('debeziumMysqlConsumer', new DebeziumMysqlConsumerService(options, app));

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -219,7 +219,6 @@ export type DefaultConsumerServiceOptions = ConsumerServiceOptions;
 export type SinkMysqlConsumerServiceOptions = ConsumerServiceOptions;
 
 export type DebeziumMysqlConsumerRecordHandler = (
-	mysql: DatabaseMysqlPoolClient,
 	name: string,
 	source: GenericObject,
 	op: string,


### PR DESCRIPTION
A native DB client does not belong in this consumer as change data messages may be read that require no DB connectivity. A MySQL DB adapter can always be loaded modularly on top of this consumer.