### PR TITLE
Optional ENV vars

### DIFF
--- a/src/configuration/index.ts
+++ b/src/configuration/index.ts
@@ -6,6 +6,7 @@ import config from 'config';
 import * as DotEnv from 'dotenv';
 import parseEnvValue from '../utils/parse-env-value';
 import { GenericOptions, InitFunction } from '../types/types';
+import { isEmpty } from 'lodash';
 
 // Load config from dotenv
 const envConfig = DotEnv.config();
@@ -37,6 +38,11 @@ export default function init(opts?: GenericOptions): InitFunction {
 
 				if (typeof value === 'object' && value !== null) {
 					value = convert(value);
+
+					// Remove empty objects
+					if (isEmpty(value)) {
+						return;
+					}
 				}
 
 				if (typeof value === 'string') {

--- a/src/configuration/index.ts
+++ b/src/configuration/index.ts
@@ -40,15 +40,23 @@ export default function init(opts?: GenericOptions): InitFunction {
 				}
 
 				if (typeof value === 'string') {
+					// Allow escaping strings that match ENV values
 					if (value.indexOf('\\') === 0) {
 						value = value.replace('\\', '');
 					} else {
+						// Check if value is in ENV
 						if (process.env[value]) {
 							value = process.env[value];
 						}
+
+						// Make relative paths absolute
 						if (value.indexOf('.') === 0 || value.indexOf('..') === 0) {
-							// Make relative paths absolute
 							value = path.resolve(path.join(config.util.getEnv('NODE_CONFIG_DIR')), value.replace(/\//g, path.sep));
+						}
+
+						// Remove all UPPERCASE_KEYS remaining as these are presumed not passed
+						if (value.trim().match(/^[A-Z_]+$/)) {
+							return;
 						}
 					}
 				}


### PR DESCRIPTION
Assume any values set in the configs files in format `UPPERCASE_KEYS` that are not found in the ENV were not set and should be removed.

Also remove any empty objects which will occur when optional args inside an object are all unset/removed.

Resolves #18 